### PR TITLE
detect_set_scale: use ratio of drawable size and window size for auto…

### DIFF
--- a/lib/b_draw.ml
+++ b/lib/b_draw.ml
@@ -925,6 +925,7 @@ let detect_set_scale () =
    else float dpi
   in
   let s = if dpi <= float default_dpi then 1. else (dpi /. (float default_dpi)) in
+  let s = Float.round (4. *. s) /. 4. in (* 0.25 increments for scale *)
   Theme.set_scale s;
   printd (debug_graphics+debug_warning) "Using SCALE=%f" !Theme.scale
 

--- a/lib/b_draw.ml
+++ b/lib/b_draw.ml
@@ -905,10 +905,28 @@ let get_dpi () =
 
 (* Choose a reasonable scale. Probably not OK in case of multiple monitors. *)
 let detect_set_scale () =
-    let dpi = default (get_dpi ()) default_dpi in
-    let s = if dpi <= 110 then 1. else (float dpi /. (float default_dpi)) in
-    Theme.set_scale s;
-    printd (debug_graphics+debug_warning) "Using SCALE=%f" !Theme.scale
+  let dpi = default (get_dpi ()) default_dpi in
+  printd debug_graphics "DPI from system: %d" dpi;
+  let dpi =
+   if Sdl.get_current_video_driver () = Some "wayland" then
+   match Sdl.create_window ~w:10 ~h:10 "SCALE detect"
+          Sdl.Window.(windowed + resizable + hidden +
+                      opengl + allow_highdpi) with
+   | Ok win ->
+      let w, h = Sdl.get_window_size win in
+      let w', h' = Sdl.gl_get_drawable_size win in
+      Sdl.destroy_window win;
+      printd debug_graphics "Autodetect multiplier: window(%d,%d), drawable(%d,%d)" w h w' h';
+      float dpi *. Float.(max (float w' /. float w) 1.)
+   | Error (`Msg m) ->
+    printd (debug_error+debug_graphics)
+      "SDL autodetect DPI window creation error: %s" m;
+    float dpi
+   else float dpi
+  in
+  let s = if dpi <= float default_dpi then 1. else (dpi /. (float default_dpi)) in
+  Theme.set_scale s;
+  printd (debug_graphics+debug_warning) "Using SCALE=%f" !Theme.scale
 
 let video_init () =
   if Sdl.was_init (Some Sdl.Init.video) = Sdl.Init.video
@@ -1244,7 +1262,7 @@ let init ?window ?(name="BOGUE Window") ?fill ?x ?y ~w ~h () =
       | Ok w -> printd debug_graphics "Using existing renderer"; w
       | Error _ ->
         go (Sdl.create_renderer ~flags:Sdl.Renderer.targettexture win) in
-  let rw, rh = go (Sdl.get_renderer_output_size renderer) in
+  let rw, rh = Sdl.gl_get_drawable_size win in
   if window = None && (rw, rh) <> (w,h) then begin
     dpi_xscale := float rw /. float w;
     dpi_yscale := float rh /. float h;


### PR DESCRIPTION
…-detection

On Fedora37, wayland with desktop scale set to 200% on a 4K screen SDL2 would detect a DPI of 92.

https://wiki.libsdl.org/SDL2/SDL_GetDisplayDPI says that the function is unreliable, and that the ratio of SDL_GL_GetDrawableSize and SDL_GetWindowSize should be used instead.

There is already a dpi_xscale/dpi_yscale that is set, but setting DPI at that point would be too late: the layout and fonts would already be loaded with the old scale.

The only way to get the desired scale was to use BOGUE_SCALE=2 env var. (Calling the various resize/set_size functions doesn't correctly refresh everything with the new scale, apparently has to be done at initialization time).

So create a fake 10 pixel window to detect scale for now.

TODO (out of scope of this PR):
The initialization order should probably be adjusted to initialize anything that depends on window size after Draw.init. Also it'd be nice if the window could react to DPI changes when moved from one monitor to another.