### PR TITLE
Switch [directories] to [xdg] to work on Windows

### DIFF
--- a/bogue.opam
+++ b/bogue.opam
@@ -32,7 +32,7 @@ depends: [
   "tsdl-ttf" {>= "0.3"}
   "ocaml" {>= "4.08.0"}
   "tsdl" {>= "0.9.7" & < "0.9.9"}
-  "directories"
+  "xdg" {>= "3.4.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -34,5 +34,5 @@ Threads when non-blocking reactions are needed.")
   (tsdl-ttf (>= 0.3))
   (ocaml (>= 4.08.0))
   (tsdl (and (>= 0.9.7) (< 0.9.9)))
-  directories
+  (xdg (>= 3.4.0))
 ))

--- a/lib/b_theme.ml
+++ b/lib/b_theme.ml
@@ -102,7 +102,7 @@ let home = Xdg.home_dir xdg
 let conf =
   let application = "bogue" in
   let config_dir = Xdg.config_dir xdg in
-  Filename.concat config_dir application
+  config_dir // application
 
 let skip_comment buffer =
   let rec loop () =

--- a/lib/b_theme.ml
+++ b/lib/b_theme.ml
@@ -95,21 +95,14 @@ let (//) = Filename.concat
 
 (* Some global environment variables *)
 
-module User_dirs = Directories.User_dirs ()
-module Project_dirs = Directories.Project_dirs (struct
-  let qualifier = "org"
-  let organization = "sanette"
-  let application = "bogue"
-end
-)
+let xdg = Xdg.create ~env:Sys.getenv_opt ()
 
-let home = match User_dirs.home_dir with
-  | None -> failwith "Can't compute home directory path."
-  | Some home -> home
+let home = Xdg.home_dir xdg
 
-let conf = match Project_dirs.config_dir with
-  | None -> failwith "Can't compute configuration directory path."
-  | Some config_dir -> config_dir
+let conf =
+  let application = "bogue" in
+  let config_dir = Xdg.config_dir xdg in
+  Filename.concat config_dir application
 
 let skip_comment buffer =
   let rec loop () =

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name bogue)
  (public_name bogue)
- (libraries directories str tsdl tsdl-image tsdl-ttf))
+ (libraries xdg str tsdl tsdl-image tsdl-ttf))
 
 (install
  (section share)


### PR DESCRIPTION
xdg.3.4.0 was the first version to have good Windows defaults.

It should be the same configuration directory on Linux but not Windows (which was never working) and not macOS. macOS used to be $HOME/Library/Application Support/<project_path> where <project_path> was qualifier.organization.application (org.sanette.bogue).

Fixes https://github.com/sanette/bogue/issues/27