### PR TITLE
Support where not which on Windows

### DIFF
--- a/lib/b_utils.ml
+++ b/lib/b_utils.ml
@@ -377,8 +377,14 @@ let list_sum list =
 let which command =
 (* BETTER: (specially for portability to WIN/MAC) use
    https://opam.ocaml.org/packages/fileutils/ *)
+  let cmdline command =
+    if Sys.win32 then
+      "where " ^ command ^ " 2> NUL"
+    else
+      "which " ^ command ^ " 2>/dev/null"
+    in
   try
-    let s = Unix.open_process_in ("which " ^ command) in
+    let s = Unix.open_process_in (cmdline command) in
     let res = try
         Some (input_line s)
       with


### PR DESCRIPTION
Described in https://github.com/sanette/bogue/issues/32 as "Getting warnings on startup because which is not a Windows program".

Also do not print the stderr. A message like:
`   INFO: Could not find files for the given pattern(s).`
is useless to the user printed on the console.